### PR TITLE
pass 'fields' argument to modelform_factory

### DIFF
--- a/inplaceeditform/fields.py
+++ b/inplaceeditform/fields.py
@@ -106,7 +106,7 @@ class BaseAdaptorField(object):
         return config
 
     def get_form_class(self):
-        return modelform_factory(self.model)
+        return modelform_factory(self.model, fields=(self.field_name,)))
 
     def get_form(self):
         form_class = self.get_form_class()


### PR DESCRIPTION
Fixes issue with required model fields invalidating inplaceeditform for
other fields from the same model. The form_class returned by
get_form_class() only needs to have the field being edited.